### PR TITLE
Use animated, pulsing status indicator for rooms in "running" state

### DIFF
--- a/app/assets/stylesheets/admins.scss
+++ b/app/assets/stylesheets/admins.scss
@@ -97,3 +97,16 @@
   z-index: 999;
   background: white;
 }
+
+.pulse {
+  animation: pulse-animation 2s infinite;
+}
+
+@keyframes pulse-animation {
+  0% {
+    box-shadow: 0 0 0 0px rgba(0, 0, 0, 0.2);
+  }
+  100% {
+    box-shadow: 0 0 0 12px rgba(0, 0, 0, 0);
+  }
+}

--- a/app/views/admins/components/_rooms.html.erb
+++ b/app/views/admins/components/_rooms.html.erb
@@ -19,6 +19,7 @@
       <table id="rooms-table" class="table table-hover table-outline table-vcenter text-nowrap card-table">
         <thead>
           <tr>
+            <th title="<%= t("administrator.rooms.table.status") %>"></th>
             <th data-header="name" data-order="<%= @order_column == "name" ? @order_direction : "none" %>">
               <%= t("administrator.users.table.name") %>
               <% if @order_column == "name" && @order_direction == "desc" %>
@@ -42,12 +43,6 @@
               <% elsif @order_column == "uid" && @order_direction == "asc" %>
                 ↑
               <% end %>
-            </th>
-            <th>
-              <%= t("administrator.rooms.table.participants") %>
-            </th>
-            <th>
-              <%= t("administrator.rooms.table.status") %>
             </th>
             <th class="text-center"><i class="icon-settings"></i></th>
           </tr>

--- a/app/views/admins/components/_server_room_row.html.erb
+++ b/app/views/admins/components/_server_room_row.html.erb
@@ -13,7 +13,16 @@
 # with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 %>
 
+<% running = room_is_running(room.bbb_id) %>
+
 <tr class="room-block" data-path="<%= update_settings_path(room) %>" data-room-settings=<%= room.room_settings %> data-room-access-code="<%= room.access_code %>">
+  <td class="text-left w-0 pr-4">
+    <% if running %>
+      <i class="fas fa-circle rounded-circle text-primary pulse" title="<%= t("administrator.rooms.table.running") %>"></i>
+    <% else %>
+      <small><i class="far fa-circle rounded-circle text-muted" title="<%= t("administrator.rooms.table.not_running") %>"></i></small>
+    <% end %>
+  </td>
   <td>
     <div id="room-title" class="form-inline edit_hover_class">
       <% if room.id == room.owner.room_id %>
@@ -24,9 +33,10 @@
       </span>
     </div>
     <div class="small text-muted">
-      <% running = room_is_running(room.bbb_id) %>
       <% if running %>
          <%= t("administrator.rooms.table.started", session: friendly_time(room.last_session)) %>
+         &middot;
+         <%= t("administrator.rooms.table.participants") %>: <%= @participants_count[room.bbb_id].presence %>
       <% elsif room.last_session.present? %>
         <%= t("administrator.rooms.table.ended", session: friendly_time(room.last_session)) %>
       <% else %>
@@ -40,17 +50,7 @@
   <td class="text-left">
     <%= room.uid %>
   </td>
-  <td class="text-center">
-    <%= @participants_count[room.bbb_id].presence || "-" %>
-  </td>
-  <td class="text-left">
-    <% if running %>
-      <%= t("administrator.rooms.table.running") %>
-    <% else %>
-      <%= t("administrator.rooms.table.not_running") %>
-    <% end %>
-  </td>
-  <td class="text-center">
+  <td class="text-right w-0>
     <div class="item-action dropdown">
       <a href="javascript:void(0)" data-toggle="dropdown" class="icon">
         <i class="fas fa-ellipsis-v px-4"></i>

--- a/app/views/admins/components/_server_room_row.html.erb
+++ b/app/views/admins/components/_server_room_row.html.erb
@@ -47,8 +47,8 @@
   <td class="text-left">
     <%= room.owner.name %>
   </td>
-  <td class="text-left">
-    <%= room.uid %>
+  <td class="text-left text-monospace">
+    <small><%= room.uid %></small>
   </td>
   <td class="text-right w-0>
     <div class="item-action dropdown">


### PR DESCRIPTION
Hey Ahmad, I saw your PR in https://github.com/bigbluebutton/greenlight/pull/1524 - and I had some ideas for this screen that I had stored anyways. So I've added some modifications on top of your code, here's a quick screenshot:

![Screen Shot 2020-05-08 at 20 41 42](https://user-images.githubusercontent.com/706419/81440365-3a60ab80-9170-11ea-9382-629529bda0f7.png)

By using this indicator it should be easier for a user to scan the table and get a quick overview of what's happening. At the same time we will have some more whitespace for other columns, which goes back to some of the other issues in the main repository regarding that the table might feel overcrowded or content will overflow their cells when rooms have super long names for example.

Let me know if you'd prefer a separate PR in https://github.com/bigbluebutton/greenlight once your own PR was merged there first.